### PR TITLE
[Magiclysm] Update demon_spider.json

### DIFF
--- a/data/mods/Magiclysm/monsters/demon_spider.json
+++ b/data/mods/Magiclysm/monsters/demon_spider.json
@@ -77,7 +77,7 @@
     "aggression": 50,
     "morale": 100,
     "melee_skill": 9,
-    "melee_dice": 20,
+    "melee_dice": 2,
     "melee_dice_sides": 8,
     "melee_cut": 12,
     "dodge": 4,


### PR DESCRIPTION
#### Summary

SUMMARY: mods, balance "Demon Spider Melee dice off by 20 (20 vs 2)"

#### Purpose of change

Compared to other similar enemies the melee dice are an order higher than similar monsters. 
2 vs 20

#### Describe the solution

Updated the json dice to be 2 instead of 20.
